### PR TITLE
[python] Remove Redudant Conditional Statement by Passing Option

### DIFF
--- a/src/image_collector.py
+++ b/src/image_collector.py
@@ -12,8 +12,7 @@ class ImageCollector(Application):
         self.url = f'{self.base_url}/image'
 
     def save_images(self, dirname, filename):
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
+        os.makedirs(dirname, exist_ok = True)
 
         i = 1
         for image in self.__get_images__():

--- a/src/info_collector.py
+++ b/src/info_collector.py
@@ -19,8 +19,7 @@ class InfoCollector(Application):
         local_paths = ['./csv/tour_reviews.csv', 'csv/tour_reviews.csv']
         for local_path in local_paths:
             if os.path.exists(local_path):
-                if not os.path.exists(dirname):
-                    os.makedirs(dirname)
+                os.makedirs(dirname, exist_ok = True)
                 shutil.copyfile(local_path, os.path.join(dirname, filename))
                 return
 
@@ -44,8 +43,7 @@ class InfoCollector(Application):
         df_rankings.columns = self.__get_categories__()
         df                  = pd.concat([df, df_rankings], axis = 1)
 
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
+        os.makedirs(dirname, exist_ok = True)
         filepath = os.path.join(dirname, filename)
         df.to_csv(filepath)
 

--- a/src/pillow_sample.py
+++ b/src/pillow_sample.py
@@ -16,7 +16,6 @@ class PillowSample(Application):
         return self.image.resize(size).size
 
     def save_image(self, dirname, filename):
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
+        os.makedirs(dirname, exist_ok = True)
         filepath = os.path.join(dirname, filename)
         self.image.save(filepath)

--- a/src/text_extractor.py
+++ b/src/text_extractor.py
@@ -37,8 +37,7 @@ class TextExtractor(Application):
         local_paths = ['./csv/lecturer_info.csv', 'csv/lecturer_info.csv']
         for p in local_paths:
             if os.path.exists(p):
-                if not os.path.exists(dirname):
-                    os.makedirs(dirname)
+                os.makedirs(dirname, exist_ok = True)
                 shutil.copyfile(p, os.path.join(dirname, filename))
                 return
 
@@ -47,8 +46,7 @@ class TextExtractor(Application):
         df['項目']    = keys
         df['値']     = values
 
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
+        os.makedirs(dirname, exist_ok = True)
         filepath = os.path.join(dirname, filename)
         df.to_csv(filepath)
 

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -12,8 +12,7 @@ class TestApplication(unittest.TestCase):
         # Do not initialize a real webdriver during unit tests
         self.application = Application(init_webdriver = False)
         self.dirname     = os.path.join('.', 'test', 'tmp')
-        if not os.path.exists(self.dirname):
-            os.makedirs(self.dirname)
+        os.makedirs(self.dirname, exist_ok = True)
         self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
 
     def tearDown(self):


### PR DESCRIPTION
## Summary

`os.makedirs` raises `FileExistsError` if the target directory already exists.
To prevent the error, it had conditional statements.
The redundancy can be resolved by `exist_ok = True` option by ignoring the error.

```python
dirname = os.path.join('.', 'foo', 'bar')
os.makedirs(dirname)

# Ignores FileExistsError with the option
os.makedirs(dirname, exist_ok = True)

# Raises FileExistsError without the option
```