### PR TITLE
[python] Update pip Library Dependencies

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -5,7 +5,7 @@ autopep8==2.3.2
 certifi==2026.5.20
 flake8==7.3.0
 h11==0.16.0
-idna==3.17
+idna==3.18
 iniconfig==2.3.0
 invoke==3.0.3
 librt==0.11.0


### PR DESCRIPTION
## 1. Overview

This PR (`web-scrapers` #29, `[python] Update pip Library Dependencies`) is a single-package refresh of `requirements.lock`.  
The only effective change is the `idna` library; all other pinned packages stay the same.

## 2. Key Changes

- **idna `3.17` → `3.18`** — Adds a `display` argument to domain decoding that passes through invalid labels instead of raising an exception, giving callers a more forgiving way to handle malformed/invalid domain labels when decoding.

## 3. Summary

A trivial, low-risk dependency bump. `idna 3.18` is a backward-compatible patch that only **adds** an opt-in `display` parameter to decoding — existing calls behave exactly as before, so no code changes are required.

## 4. References

- [idna/HISTORY.md > 3.18 (2026-06-02)](https://github.com/kjd/idna/blob/master/HISTORY.md#318-2026-06-02)
  - [Comparing changes between 3.17 and 3.18](https://github.com/kjd/idna/compare/v3.17...v3.18)