### PR TITLE
[python] Update pip Library Dependencies

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -2,7 +2,7 @@ ast_serialize==0.5.0
 attrs==26.1.0
 autoflake8==0.4.1
 autopep8==2.3.2
-certifi==2026.5.20
+certifi==2026.6.17
 flake8==7.3.0
 h11==0.16.0
 idna==3.18


### PR DESCRIPTION
## 1. Library change

| Library | Old version | New version |
| --- | --- | --- |
| certifi | 2026.5.20 | 2026.6.17 |

Exact lines:

```diff
-certifi==2026.5.20
+certifi==2026.6.17
```

## 2. What changed

`certifi` provides **Mozilla's curated collection of root CA certificates**, used by Python TLS clients (e.g. `requests`, `urllib3`) to verify the identity of HTTPS hosts. `certifi.where()` returns the path to the bundled `cacert.pem`.

The package is **date-versioned**: the version string is the date the CA bundle was extracted from Mozilla's upstream trust store.  
A bump from **2026.5.20 → 2026.6.17** therefore means the **root certificate bundle was re-synced** with Mozilla — typically adding newly trusted CAs and/or **removing distrusted or expired ones**.  
There is **no Python code or API change**; only the `cacert.pem` data changes.

## 3. Risk / impact

- **Risk: low**, but **security-relevant**. Keeping `certifi` current ensures the scraper trusts the right CAs and rejects certificates from CAs Mozilla has distrusted.
- **Possible side effect:** because CAs can be *removed*, a host still using a certificate from a now-distrusted CA may begin failing verification after the update. This is the intended, correct behavior — but worth noting if any target site suddenly raises TLS errors after merging.
- **Action:** recommended to merge to stay aligned with the current Mozilla trust store.