### PR TITLE
[python] Update pip Library Dependencies

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -12,7 +12,7 @@ librt==0.11.0
 mccabe==0.7.0
 mypy==2.0.0
 mypy_extensions==1.1.0
-numpy==2.4.6
+numpy==2.5.0
 outcome==1.3.0.post0
 packaging==26.2
 pandas==3.0.2


### PR DESCRIPTION
## 1. Overview

This PR updates the pip library dependencies of the `deep-learnings` repository.  
The change is a single minor-level bump of `numpy`, recorded in `requirements.txt`.  
Unlike the other (patch-level) dependency updates, this is a minor release that carries deprecations and compatibility changes, so it warrants closer attention even though no project code was modified in this PR.

## 2. Key Changes & Differences in Each Library

|Libraries |Before |After |Changes & Differences |
|:-|:-|:-|:-|
| numpy | 2.4.4 | 2.5.0 | Minor release. Highlights: distutils removed; drops Python 3.11 (supports 3.12–3.14); improved free-threaded Python support; descending sorts added for array-api compliance; many 2.0.x deprecations expired. Compatibility: `linalg.eig`/`eigvals` always return complex arrays, `numpy.where` raises `OverflowError` instead of silently truncating Python ints, MSVC ≥ 19.35 and Cython ≥ 3.0 now required. New deprecations: direct `dtype`/`shape` attribute setting, `numpy.char.chararray`, `numpy.fix` (use `numpy.trunc`), in-place array resize, and the `generic` unit in `numpy.timedelta64`. |

## 3. Summary

A single library, `numpy`, was bumped from 2.4.4 to 2.5.0.  
This is a minor (not patch) release: it removes distutils, drops Python 3.11, expires several long-standing deprecations, and tightens a few behaviours (complex returns from `linalg.eig`, `OverflowError` from `numpy.where`).  
Because it introduces new deprecations and compatibility changes, it is worth verifying that the project's NumPy usage and Python version remain compatible, though no code changes were needed in this PR.

## 4. References

- [NumPy releases](https://github.com/numpy/numpy/releases)
- [NumPy 2.5.0 release notes](https://numpy.org/doc/stable/release/2.5.0-notes.html)