### PR TITLE
[github-actions] Fix Cron Jobs For Daily Library Dependencies Update

### DIFF
--- a/.github/scripts/dependency_report.sh
+++ b/.github/scripts/dependency_report.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Generate the '2. Key Changes & Differences' table for daily dependency PRs.
+#
+# Usage:
+#     dependency_report.sh <ecosystem> <lockfile> <manifest> <label>
+#
+#     ecosystem  pip | gem | pnpm
+#     lockfile   path to requirements.lock / Gemfile.lock / pnpm-lock.yaml
+#     manifest   path to requirements.txt / Gemfile / package.json
+#     label      first column heading (Libraries / Gems / Packages)
+#
+# Parses `git diff` of the lockfile and prints a markdown table describing each
+# changed dependency: the semver level of the change, the package's summary
+# fetched from its registry (PyPI / RubyGems / npm), and whether it is a direct
+# or transitive dependency.
+set -euo pipefail
+
+ecosystem=$1
+lockfile=$2
+manifest=$3
+label=$4
+
+describe() {
+  local name=$1 url filter
+  case $ecosystem in
+    pip)  url="https://pypi.org/pypi/${name}/json"           filter='.info.summary // empty' ;;
+    gem)  url="https://rubygems.org/api/v1/gems/${name}.json" filter='.info // empty' ;;
+    *)    url="https://registry.npmjs.org/${name}/latest"     filter='.description // empty' ;;
+  esac
+  curl -fsS --max-time 10 "$url" 2>/dev/null | jq -r "$filter" 2>/dev/null || true
+}
+
+clean() {
+  local description sentence
+  description=$(tr -d '\r' <<<"$1" | tr '\n\t' '  ' | sed -E 's/ +/ /g; s/^ +//; s/ +$//; s/\|/\\|/g')
+  if [[ $description == *'. '* ]]; then
+    sentence="${description%%. *}."
+    if [ "${#sentence}" -ge 20 ]; then
+      description=$sentence
+    fi
+  fi
+  if [ "${#description}" -gt 200 ]; then
+    description="$(sed -E 's/ +$//' <<<"${description:0:197}")..."
+  fi
+  if [[ -n $description && $description != *. ]]; then
+    description+="."
+  fi
+  printf '%s' "$description"
+}
+
+level() {
+  local old new i
+  local -a olds news
+  IFS=. read -ra olds <<<"$1"
+  IFS=. read -ra news <<<"$2"
+  for ((i = 0; i < ${#olds[@]} || i < ${#news[@]}; i++)); do
+    old=${olds[i]:-0}
+    new=${news[i]:-0}
+    if [ "$old" != "$new" ]; then
+      case $i in
+        0) printf 'Major-level update' ;;
+        1) printf 'Minor-level update' ;;
+        *) printf 'Patch-level update' ;;
+      esac
+      return
+    fi
+  done
+  printf 'Patch-level update'
+}
+
+declare -A before after direct
+
+while IFS= read -r line; do
+  case $ecosystem in
+    pip)
+      [[ $line =~ ^([+-])([A-Za-z0-9][A-Za-z0-9._-]*)==([^[:space:]]+)$ ]] || continue
+      ;;
+    gem)
+      [[ $line =~ ^([+-])\ {4}([^\ ]+)\ \(([0-9][^\)]*)\)$ ]] || continue
+      ;;
+    *)
+      [[ $line == *'('* ]] && continue
+      [[ $line =~ ^([+-])\ \ \'?(.+)@([0-9][^\':]*)\'?:?$ ]] || continue
+      ;;
+  esac
+  if [ "${BASH_REMATCH[1]}" = '-' ]; then
+    before[${BASH_REMATCH[2]}]=${BASH_REMATCH[3]}
+  else
+    after[${BASH_REMATCH[2]}]=${BASH_REMATCH[3]}
+  fi
+done < <(git diff --unified=0 -- "$lockfile")
+
+if [ -f "$manifest" ]; then
+  case $ecosystem in
+    pip)
+      while IFS= read -r name; do
+        direct[$name]=1
+      done < <(sed -nE 's/^([A-Za-z0-9][A-Za-z0-9._-]*).*/\1/p' "$manifest" | tr 'A-Z_' 'a-z-')
+      ;;
+    gem)
+      while IFS= read -r name; do
+        direct[$name]=1
+      done < <(sed -nE "s/^[[:space:]]*gem ['\"]([^'\"]+)['\"].*/\1/p" "$manifest")
+      ;;
+    *)
+      while IFS= read -r name; do
+        direct[$name]=1
+      done < <(jq -r '((.dependencies // {}) + (.devDependencies // {})) | keys[]' "$manifest" 2>/dev/null | tr -d '\r' || true)
+      ;;
+  esac
+fi
+
+rows=''
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  old=${before[$name]:-}
+  new=${after[$name]:-}
+  [ "$old" = "$new" ] && continue
+  if [ -n "$old" ] && [ -n "$new" ]; then
+    what=$(level "$old" "$new")
+  elif [ -n "$new" ]; then
+    what='Newly added'
+  else
+    what='Removed'
+  fi
+  description=$(clean "$(describe "$name")")
+  normalised=$name
+  if [ "$ecosystem" = 'pip' ]; then
+    normalised=$(tr 'A-Z_' 'a-z-' <<<"$name")
+  fi
+  if [ -n "${direct[$normalised]:-}" ]; then
+    kind='Direct'
+  else
+    kind='Transitive'
+  fi
+  notes="${what}. ${description:+$description }${kind} dependency."
+  old_cell=${old:+\`$old\`}
+  new_cell=${new:+\`$new\`}
+  rows+="|\`${name}\` |${old_cell:--} |${new_cell:--} |${notes} |"$'\n'
+done < <(printf '%s\n' "${!before[@]}" "${!after[@]}" | sort -fu)
+
+echo "|${label} |Before |After |Changes & Differences |"
+echo '|:-|:-|:-|:-|'
+if [ -n "$rows" ]; then
+  printf '%s' "$rows"
+else
+  echo '| | | |No dependency changes detected |'
+fi

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  update:
+  update_pip_library_dependencies:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -87,4 +87,4 @@ jobs:
           title: "[Daily][Python] Update pip Library Dependencies"
           body-path: ${{ runner.temp }}/pr_body.md
           reviewers: hayat01sh1da
-          assignees: github-actions[bot]
+          assignees: hayat01sh1da

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -19,10 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: .python-version
+      - uses: ./.github/actions/setup-python
       - name: Update pip Library Dependencies
         working-directory: .
         run: |

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -43,24 +43,8 @@ jobs:
         env:
           BODY_PATH: ${{ runner.temp }}/pr_body.md
         run: |
-          ROWS=$(git diff --unified=0 -- requirements.lock \
-            | grep -E '^[+-][A-Za-z0-9]' \
-            | sed -E 's/^(.)/\1 /; s/==/ /' \
-            | awk '{ if ($1 == "-") before[$2] = $3; else after[$2] = $3 }
-              END {
-                for (name in after) {
-                  if (name in before) {
-                    if (before[name] != after[name]) print "|" name " |" before[name] " |" after[name] " |Updated |"
-                    delete before[name]
-                  } else {
-                    print "|" name " |- |" after[name] " |Added |"
-                  }
-                }
-                for (name in before) print "|" name " |" before[name] " |- |Removed |"
-              }' \
-            | sort)
-          if [ -z "$ROWS" ]; then ROWS='| | | |No dependency changes detected |'; fi
-          cat > "$BODY_PATH" <<EOF
+          {
+            cat <<'OVERVIEW'
           ## 1. Overview
 
           This pull request was created automatically by the Python - Daily Dependencies Update workflow.
@@ -73,10 +57,10 @@ jobs:
           ~~~
 
           ## 2. Key Changes & Differences
-
-          |Libraries |Before |After |Changes & Differences |
-          |:-|:-|:-|:-|
-          $ROWS
+          OVERVIEW
+            echo
+            bash .github/scripts/dependency_report.sh pip requirements.lock requirements.txt Libraries
+            cat <<SUMMARY
 
           ## 3. Summary
 
@@ -87,7 +71,8 @@ jobs:
 
           - [Python - Daily Dependencies Update workflow run](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)
           - [pip install documentation](https://pip.pypa.io/en/stable/cli/pip_install/)
-          EOF
+          SUMMARY
+          } > "$BODY_PATH"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -24,8 +24,21 @@ jobs:
         working-directory: .
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt --upgrade
+          sed -E 's/==.*//' requirements.txt | xargs pip install --upgrade
           pip freeze > requirements.lock
+      - name: Mirror Updated Versions to requirements.txt
+        working-directory: .
+        run: |
+          python - <<'PY'
+          import re
+          from importlib.metadata import version
+          with open('requirements.txt') as f:
+              lines = f.read().splitlines()
+          with open('requirements.txt', 'w') as f:
+              for line in lines:
+                  m = re.match(r'([A-Za-z0-9._-]+)==\S+$', line.strip())
+                  f.write(f'{m.group(1)}=={version(m.group(1))}\n' if m else line + '\n')
+          PY
       - name: Generate Pull Request Description
         env:
           BODY_PATH: ${{ runner.temp }}/pr_body.md
@@ -51,11 +64,11 @@ jobs:
           ## 1. Overview
 
           This pull request was created automatically by the Python - Daily Dependencies Update workflow.
-          It upgrades pip itself, upgrades every library listed in requirements.txt to the latest available versions, and regenerates requirements.lock:
+          It upgrades pip itself, upgrades every library listed in requirements.txt to the latest available versions, regenerates requirements.lock, and mirrors the updated versions to requirements.txt:
 
           ~~~console
           pip install --upgrade pip
-          pip install -r requirements.txt --upgrade
+          sed -E 's/==.*//' requirements.txt | xargs pip install --upgrade
           pip freeze > requirements.lock
           ~~~
 
@@ -67,7 +80,7 @@ jobs:
 
           ## 3. Summary
 
-          All pip library dependencies in requirements.lock are now up to date.
+          All pip library dependencies in requirements.txt and requirements.lock are now up to date.
           Please make sure that all CI workflows pass before merging this pull request.
 
           ## 4. References
@@ -80,6 +93,9 @@ jobs:
         with:
           branch: daily/python-dependency-updates
           delete-branch: true
+          add-paths: |
+            requirements.txt
+            requirements.lock
           commit-message: "[Daily][Python] Update pip Library Dependencies"
           title: "[Daily][Python] Update pip Library Dependencies"
           body-path: ${{ runner.temp }}/pr_body.md


### PR DESCRIPTION
## 1. Overview

This topic branch fixes the daily dependencies update cron jobs that have been failing since 2026-07-08 and modernises them.  
The nightly `Create Pull Request` step began erroring with `Assigning agents is not supported with GitHub App installation tokens` — GitHub no longer allows assigning bot accounts (`github-actions[bot]`) with the workflow's `GITHUB_TOKEN`, and because the step aborts there, the reviewer request was never applied either.

On top of that fix, the branch cleans the workflows up in commit-per-concern units: consistent job names, reuse of the repository's shared `.github/actions/setup-*` composite actions instead of inline setup steps, mirroring of updated versions back to the manifests (`requirements.txt` / `Gemfile`), and a far more detailed `2. Key Changes & Differences` section on the generated daily PRs.

## 2. Key Changes & Differences

|Workflows |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|dependency_report.sh |- |Shared shell script (curl + jq) |Newly added. Generates the detailed `2. Key Changes & Differences` table for the daily PRs: semver level of each change, package summary fetched from PyPI / RubyGems / npm, and direct vs. transitive classification. |
|python--daily-dependencies-update.yml |`update` job; inline setup steps; upgrades capped by `==` pins; `assignees: github-actions[bot]`; terse change table |`update_pip_library_dependencies` job; `./.github/actions/setup-python`; upgrades to latest and mirrors pins to requirements.txt; `assignees: hayat01sh1da`; detailed change table via dependency_report.sh |Fixed the nightly failure (bot accounts can no longer be assigned with App installation tokens) so reviewer/assignee are applied again. Libraries now actually reach the latest versions and requirements.txt stays in sync. |

## 3. Summary

1 daily dependencies update workflow(s) fixed and modernised, and 1 shared report script added.  
Once this is merged, the next scheduled run (0:00 JST nightly) should complete again end-to-end: update dependencies, mirror the manifests, open the daily PR with a detailed description, and apply `hayat01sh1da` as reviewer and assignee.  
Please make sure that all CI workflows pass before merging this pull request.

## 4. References

- https://github.com/hayat01sh1da/web-scrapers/blob/hayat01sh1da/github-actions/fix-cron-jobs-for-daily-library-dependencies-update/.github/scripts/dependency_report.sh
- https://github.com/hayat01sh1da/web-scrapers/blob/hayat01sh1da/github-actions/fix-cron-jobs-for-daily-library-dependencies-update/.github/workflows/python--daily-dependencies-update.yml
- https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue
- https://github.com/peter-evans/create-pull-request
- https://docs.github.com/actions/sharing-automations/creating-actions/creating-a-composite-action
