### PR TITLE
[github-actions] Add Update of Package Manager on Cron Job for Daily Library Dependencies Update

### DIFF
--- a/.github/scripts/dependency_report.sh
+++ b/.github/scripts/dependency_report.sh
@@ -12,7 +12,9 @@
 # Parses `git diff` of the lockfile and prints a markdown table describing each
 # changed dependency: the semver level of the change, the package's summary
 # fetched from its registry (PyPI / RubyGems / npm), and whether it is a direct
-# or transitive dependency.
+# or transitive dependency. Package-manager updates are reported too: pip as a
+# regular requirements.lock entry, bundler from the lockfile's BUNDLED WITH
+# section, and pnpm from the manifest's packageManager field.
 set -euo pipefail
 
 ecosystem=$1
@@ -90,6 +92,44 @@ while IFS= read -r line; do
   fi
 done < <(git diff --unified=0 -- "$lockfile")
 
+# bundler and pnpm versions live outside the dependency stanzas parsed above:
+# bundler in the lockfile's BUNDLED WITH section and pnpm in the manifest's
+# packageManager field. pip needs no extra handling here because it is a
+# regular requirements.lock entry.
+bundled_with() {
+  awk 'prev == "BUNDLED WITH" { print $1; exit } { prev = $0 }'
+}
+
+pinned_pnpm() {
+  jq -r '.packageManager // empty' 2>/dev/null | sed -E 's/^[^@]+@//; s/\+.*$//'
+}
+
+manager_before=''
+manager_after=''
+case $ecosystem in
+  pip)
+    manager=pip
+    ;;
+  gem)
+    manager=bundler
+    if head_file=$(git show "HEAD:$lockfile" 2>/dev/null); then
+      manager_before=$(bundled_with <<<"$head_file" || true)
+      manager_after=$(bundled_with < "$lockfile" || true)
+    fi
+    ;;
+  *)
+    manager=pnpm
+    if head_file=$(git show "HEAD:$manifest" 2>/dev/null); then
+      manager_before=$(pinned_pnpm <<<"$head_file" || true)
+      manager_after=$(pinned_pnpm < "$manifest" || true)
+    fi
+    ;;
+esac
+if [ "$manager_before" != "$manager_after" ]; then
+  if [ -n "$manager_before" ]; then before[$manager]=$manager_before; fi
+  if [ -n "$manager_after" ]; then after[$manager]=$manager_after; fi
+fi
+
 if [ -f "$manifest" ]; then
   case $ecosystem in
     pip)
@@ -128,12 +168,14 @@ while IFS= read -r name; do
   if [ "$ecosystem" = 'pip' ]; then
     normalised=$(tr 'A-Z_' 'a-z-' <<<"$name")
   fi
-  if [ -n "${direct[$normalised]:-}" ]; then
-    kind='Direct'
+  if [ "$name" = "$manager" ]; then
+    kind='Package manager.'
+  elif [ -n "${direct[$normalised]:-}" ]; then
+    kind='Direct dependency.'
   else
-    kind='Transitive'
+    kind='Transitive dependency.'
   fi
-  notes="${what}. ${description:+$description }${kind} dependency."
+  notes="${what}. ${description:+$description }${kind}"
   old_cell=${old:+\`$old\`}
   new_cell=${new:+\`$new\`}
   rows+="|\`${name}\` |${old_cell:--} |${new_cell:--} |${notes} |"$'\n'

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -26,6 +26,7 @@ jobs:
           pip install --upgrade pip
           sed -E 's/==.*//' requirements.txt | xargs pip install --upgrade
           pip freeze > requirements.lock
+          pip --version | awk '{print "pip==" $2}' >> requirements.lock
       - name: Mirror Updated Versions to requirements.txt
         working-directory: .
         run: |
@@ -48,12 +49,13 @@ jobs:
           ## 1. Overview
 
           This pull request was created automatically by the Python - Daily Dependencies Update workflow.
-          It upgrades pip itself, upgrades every library listed in requirements.txt to the latest available versions, regenerates requirements.lock, and mirrors the updated versions to requirements.txt:
+          It upgrades pip itself, upgrades every library listed in requirements.txt to the latest available versions, regenerates requirements.lock (which also records the pip version), and mirrors the updated versions to requirements.txt:
 
           ~~~console
           pip install --upgrade pip
           sed -E 's/==.*//' requirements.txt | xargs pip install --upgrade
           pip freeze > requirements.lock
+          pip --version | awk '{print "pip==" $2}' >> requirements.lock
           ~~~
 
           ## 2. Key Changes & Differences


### PR DESCRIPTION
## 1. Overview

This pull request improves the Daily Dependencies Update cron workflows so that package manager version updates are reflected in the pull request description.

Previously, the `2. Key Changes & Differences` table was built only from the dependency stanzas of the lockfile diff, so package manager version updates were invisible. In particular, the version of pip itself was not recorded in any tracked file, so a pip upgrade could never appear in any diff.

This pull request:

- Makes `dependency_report.sh` report package manager version updates: `bundler` from the `BUNDLED WITH` section of `Gemfile.lock`, `pnpm` from the `packageManager` field of `package.json`, and `pip` as a regular `requirements.lock` entry. Such rows are labelled `Package manager.` instead of `Direct/Transitive dependency.`.
- Makes the Python workflow record the upgraded pip version as a `pip==<version>` line in `requirements.lock`, which the report then picks up from the lockfile diff.

## 2. Key Changes & Differences

|Files |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`.github/scripts/dependency_report.sh` |Only dependency version changes parsed from the lockfile diff were reported; package manager updates never appeared in the table |Also reports package manager version updates (`bundler` via `BUNDLED WITH`, `pnpm` via `packageManager`, `pip` via its `requirements.lock` entry) with a `Package manager.` label |Fixes daily PRs showing "No dependency changes detected" when only the package manager was updated |
|`.github/workflows/python--daily-dependencies-update.yml` |pip was upgraded on the runner but its version was not recorded in any tracked file |Appends `pip==<version>` to `requirements.lock` after `pip freeze` |pip upgrades now appear in the lockfile diff and in the PR description table |

## 3. Summary

- 2 files changed: the shared dependency report script and the daily dependencies update workflow.
- The first daily run after merging will report `pip` as `Newly added`, since their versions enter version tracking for the first time.
- Please make sure that all CI workflows pass before merging this pull request.

## 4. References

- [.github/scripts/dependency_report.sh](https://github.com/hayat01sh1da/web-scrapers/blob/hayat01sh1da/github-actions/add-update-of-package-manager-on-cron-job-for-daily-library-dependencies-update/.github/scripts/dependency_report.sh)
- [.github/workflows/python--daily-dependencies-update.yml](https://github.com/hayat01sh1da/web-scrapers/blob/hayat01sh1da/github-actions/add-update-of-package-manager-on-cron-job-for-daily-library-dependencies-update/.github/workflows/python--daily-dependencies-update.yml)
- [pip freeze documentation](https://pip.pypa.io/en/stable/cli/pip_freeze/)
