### PR TITLE
[github-actions] Bump actions/checkout Version from v6 to v7

### DIFF
--- a/.github/workflows/python--ci.yml
+++ b/.github/workflows/python--ci.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       python-changes: ${{ steps.change-detection.outputs.python }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection
@@ -51,7 +51,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.python-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: flake8
         working-directory: .
@@ -66,7 +66,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.python-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: pytest
         working-directory: .
@@ -80,7 +80,7 @@ jobs:
     needs: change-detection
     if: needs.change-detection.outputs.python-changes == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: mypy
         working-directory: .

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
       - name: Update pip Library Dependencies
         working-directory: .


### PR DESCRIPTION
## 1. Overview

The primary difference between actions/checkout@v6 and actions/checkout@v7 is a critical security enforcement that blocks untrusted code execution from fork pull requests by default.

## 2. Key Differences Overview

- **Fork Pull Request Protection (Breaking Change)**: v7 refuses to check out fork pull request code when a workflow is triggered by `pull_request_target` or `workflow_run`. This stops "pwn request" supply-chain attacks, where malicious actors use a fork PR to run unauthorized code with your base repository's elevated `GITHUB_TOKEN` and secrets.
- New Configuration Input: v7 introduces the `allow-unsafe-pr-checkout` flag. You must explicitly set this to `true` if your workflow deliberately requires checking out untrusted code from a fork under privileged triggers.
- **Under-the-Hood Migration**: `v7` shifts the entire action to **ECMAScript Modules (ESM)** to accommodate newer `@actions/*` internal package requirements.
- **Dependency & Security Patches**: `v7` includes major direct and transitive dependency updates to remediate known vulnerabilities.

## 3. Comparison of Key Features

|Feature / Behavior |actions/checkout@v6 |actions/checkout@v7 |
|:-|:-|:-|
**|Fork checkouts on `pull_request_target`** |Allowed automatically (Vulnerable to exploit) |**Blocked by default** (Throws an error) |
|**New Input: `allow-unsafe-pr-checkout`** |Not available |**Available** (Defaults to `false`) |
|I**nternal Module System** |CommonJS (CJS) |**ECMAScript Modules (ESM)** |
|**Credential Persistence Strategy** |Saved in `$RUNNER_TEMP` via `includeIf` |Saved in `$RUNNER_TEMP` via `includeIf` |

## 4. References

- [actions/checkout: Action for checking out a repo - GitHub](https://github.com/actions/checkout)
- [pull_request_targetでcheckoutできなくなった - Zenn](https://zenn.dev/catatsuy/scraps/9142e8c6b7a5cd)
- [Safer pull_request_target defaults for GitHub Actions checkout - The GitHub Blog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)
- [GitHub Updates actions/checkout to Block Common Pwn Request Attack Patterns - The Hacker News](https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html)
- [GitHub Actions checkout v7 improves security defaults - Linkedin](https://www.linkedin.com/posts/github-securitylab_a-step-towards-making-github-actions-more-activity-7473412207435874304-EsN8)